### PR TITLE
Fix gcpckms issues

### DIFF
--- a/charts/boundary-chart/templates/configmap.yaml
+++ b/charts/boundary-chart/templates/configmap.yaml
@@ -105,6 +105,7 @@ data:
       {{- end }}
     }
     {{- end }}
+
     {{- if .Values.vault.enabled }}
     {{- $fqdn := .Values.vault.fqdn }}
     {{- $mountPath := .Values.vault.mountPath }}
@@ -122,6 +123,8 @@ data:
       {{- end }}
     }
     {{- end }}
+    {{- end }}
+
     {{- if .Values.aead.enabled }}
     {{- range $purpose, $key := .Values.aead.keys }}
     kms "aead" {
@@ -132,15 +135,18 @@ data:
     }
     {{- end }}
     {{- end }}
+
     {{- if .Values.gcpckms.enabled }}
+    {{- range $i, $purpose := list "root" "recovery" "worker-auth" }}
     kms "gcpckms" {
-      purpose = "{{ .Values.gcpckms.purpose }}"
-      credentials = "{{ .Values.gcpckms.credentials }}"
-      project = "{{ .Values.gcpckms.project }}"
-      region = "{{ .Values.gcpckms.region }}"
-      key_ring = "{{ .Values.gcpckms.key_ring }}"
-      crypto_key = "{{ .Values.gcpckms.crypto_key }}"
+      purpose = "{{ $purpose }}"
+      credentials = "{{ $.Values.gcpckms.credentials }}"
+      project = "{{ $.Values.gcpckms.project }}"
+      region = "{{ $.Values.gcpckms.region }}"
+      key_ring = "{{ $.Values.gcpckms.key_ring }}"
+      crypto_key = "{{ $.Values.gcpckms.crypto_key }}"
     }
+    {{- end }}
     {{- end }}
   boundary-config.hcl: |
     disable_mlock = true
@@ -244,6 +250,7 @@ data:
       {{- end }}
     }
     {{- end }}
+
     {{- if .Values.vault.enabled }}
     {{- $fqdn := .Values.vault.fqdn }}
     {{- $mountPath := .Values.vault.mountPath }}
@@ -261,6 +268,8 @@ data:
       {{- end }}
     }
     {{- end }}
+    {{- end }}
+
     {{- if .Values.aead.enabled }}
     {{- range $purpose, $key := .Values.aead.keys }}
     kms "aead" {
@@ -271,13 +280,17 @@ data:
     }
     {{- end }}
     {{- end }}
+    
+    
     {{- if .Values.gcpckms.enabled }}
+    {{- range $i, $purpose := list "root" "recovery" "worker-auth" }}
     kms "gcpckms" {
-      purpose = "{{ .Values.gcpckms.purpose }}"
-      credentials = "{{ .Values.gcpckms.credentials }}"
-      project = "{{ .Values.gcpckms.project }}"
-      region = "{{ .Values.gcpckms.region }}"
-      key_ring = "{{ .Values.gcpckms.key_ring }}"
-      crypto_key = "{{ .Values.gcpckms.crypto_key }}"
+      purpose = "{{ $purpose }}"
+      credentials = "{{ $.Values.gcpckms.credentials }}"
+      project = "{{ $.Values.gcpckms.project }}"
+      region = "{{ $.Values.gcpckms.region }}"
+      key_ring = "{{ $.Values.gcpckms.key_ring }}"
+      crypto_key = "{{ $.Values.gcpckms.crypto_key }}"
     }
+    {{- end }}
     {{- end }}

--- a/charts/boundary-chart/templates/deployment.yaml
+++ b/charts/boundary-chart/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
             - name: boundary-config
               mountPath: /boundary
               readOnly: true
+          {{- if .Values.volumeMounts }}
+            {{- toYaml .Values.volumeMounts | nindent 12}}
+          {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
1) `gcpckms` commit was missing an `{{- end }}` block for the `.Values.vault.enabled` if.
2) Added `range` for `gcpckms purposes`
3) Added `.Values.volumeMounts` to the init container. Future improvement would be to have a dedicated `initContainer` section in the `values.yaml` potentially, so we can mount separate volumes to each container. The volume mount was required for `gcpckms` to mount a `serviceAccount json`.